### PR TITLE
Forcing output format, getting rid of console color sequences and turning on profiling

### DIFF
--- a/bin/blaze
+++ b/bin/blaze
@@ -12,4 +12,4 @@ auto_configure ${WORKSPACE} ${JOB_NAME} && \
     cd ${WORKSPACE} && \
     bundle --without production && \
     bundle exec rake db:drop db:create db:schema:load && \
-    xvfb-run -a bundle exec rspec spec
+    xvfb-run -a bundle exec rspec --format progress --no-color --profile spec


### PR DESCRIPTION
This will reduce junk in output and help us to trace slowest examples.
