### PR TITLE
Fix variable assignment

### DIFF
--- a/bin/blaze
+++ b/bin/blaze
@@ -18,7 +18,7 @@ fi
 
 if [ -z "${SPEC_FILES}" ]
 then
-  $SPEC_FILES=spec
+  SPEC_FILES=spec
 fi
 
 export RAILS_ENV=test


### PR DESCRIPTION
Bash variables should be assigned without the '$' in front,
the current form is broken.
