### PR TITLE
Extra arguments to RSpec

### DIFF
--- a/bin/blaze
+++ b/bin/blaze
@@ -29,4 +29,4 @@ auto_configure ${WORKSPACE} ${JOB_NAME} && \
   cd ${WORKSPACE} && \
   bundle --without production && \
   bundle exec rake db:drop db:create db:schema:load && \
-  xvfb-run -a bundle exec rspec --format doc --no-color --profile ${SPEC_FILES}
+  xvfb-run -a bundle exec rspec --format doc --no-color --profile ${EXTRA_RSPEC_ARGS} ${SPEC_FILES}


### PR DESCRIPTION
This way we can easily set up on Jenkins two separate builds, that will
(or will not) run the specs with a particular tag:

blaze EXTRA_RSPEC_ARGS="--tag '~external_connections'"
blaze EXTRA_RSPEC_ARGS="--tag 'external_connections'"
