### PR TITLE
Verifies database adapter on a platform basis

### DIFF
--- a/lib/railblazer.rb
+++ b/lib/railblazer.rb
@@ -3,5 +3,6 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__)))
 require 'extensions/hash'
 require 'railblazer/auto_configure/cli'
 require 'railblazer/adapter_detection'
+require 'railblazer/gem'
 require 'railblazer/minimal_gemfile'
 require 'railblazer/template'

--- a/lib/railblazer/gem.rb
+++ b/lib/railblazer/gem.rb
@@ -1,0 +1,26 @@
+module Railblazer
+  class Gem
+    def initialize(name, args)
+      @name = name
+      @args = args.last || {}
+    end
+
+    def for_current_platform?
+      (platform?(:jruby) && ruby_platform == "java") ||
+        (platform?(:mri) && ruby_platform != "java") ||
+        (args[:platform].nil?)
+    end
+
+    private
+
+    attr_accessor :args
+
+    def platform?(platform)
+      Array(args[:platform]).include?(platform)
+    end
+
+    def ruby_platform
+      RUBY_PLATFORM
+    end
+  end
+end

--- a/lib/railblazer/minimal_gemfile.rb
+++ b/lib/railblazer/minimal_gemfile.rb
@@ -10,7 +10,7 @@ module Railblazer
     end
 
     def gem name, *args
-      @gems << name
+      @gems << name if Gem.new(name, args).for_current_platform?
     end
 
     def group *args, &block

--- a/spec/railblazer/gem_spec.rb
+++ b/spec/railblazer/gem_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Railblazer::Gem do
+  describe "#for_current_platform?" do
+    it "returns true if ruby platform is Java and gem platform is jruby" do
+      gem = Railblazer::Gem.new("pg", [{platform: :jruby}])
+      gem.stubs(:ruby_platform).returns("java")
+      gem.for_current_platform?.must_equal true
+    end
+
+    it "returns false if ruby platform is Java and gem platform is mri" do
+      gem = Railblazer::Gem.new("pg", [{platform: :mri}])
+      gem.stubs(:ruby_platform).returns("java")
+      gem.for_current_platform?.must_equal false
+    end
+
+    it "returns true if ruby platform is not Java and gem platform is mri" do
+      gem = Railblazer::Gem.new("pg", [{platform: :mri}])
+      gem.stubs(:ruby_platform).returns("something_entirely_different")
+      gem.for_current_platform?.must_equal true
+    end
+
+    it "returns false if ruby platform is not Java and gem platform is jruby" do
+      gem = Railblazer::Gem.new("pg", [{platform: :jruby}])
+      gem.stubs(:ruby_platform).returns("something_entirely_different")
+      gem.for_current_platform?.must_equal false
+    end
+
+    it "returns true if no gem platform is specified" do
+      gem = Railblazer::Gem.new("pg", [])
+      gem.stubs(:ruby_platform).returns("java")
+      gem.for_current_platform?.must_equal true
+    end
+
+    it "works when platform is an array" do
+      gem = Railblazer::Gem.new("pg", [{platform: [:jruby]}])
+      gem.stubs(:ruby_platform).returns("java")
+      gem.for_current_platform?.must_equal true
+    end
+  end
+end

--- a/spec/railblazer/minimal_gemfile_spec.rb
+++ b/spec/railblazer/minimal_gemfile_spec.rb
@@ -16,21 +16,35 @@ describe Railblazer::MinimalGemfile do
     it "should detect gems inside of group blocks" do
       mysql_gemfile = <<-EOF
         gem 'mysql'
+        gem 'pg', platform: :jruby
         group 'development' do
-          gem 'othergem'  
+          gem 'othergem'
         end
       EOF
 
       Railblazer::MinimalGemfile.new(StringIO.new(mysql_gemfile)).gems.must_equal %w[mysql othergem].to_set
     end
 
+    it "should detect for the current platform" do
+      mysql_gemfile = <<-EOF
+        gem 'mysql', platform: :mri
+        gem 'pg', platform: :jruby
+        group 'development' do
+          gem 'othergem'
+        end
+      EOF
+
+      Railblazer::Gem.any_instance.stubs(:ruby_platform).returns("java")
+      Railblazer::MinimalGemfile.new(StringIO.new(mysql_gemfile)).gems.must_equal %w[pg othergem].to_set
+    end
+
     it "should ignore other methods in the Gemfile" do
       mysql_gemfile = <<-EOF
         gem 'mysql'
         funky_method
-      
+
         group 'development' do
-          gem 'othergem'  
+          gem 'othergem'
         end
       EOF
 


### PR DESCRIPTION
It's normal to have in your Gemfile more than one platform (JRuby, MRI
etc). Railbrazer, though, is not considering it when choosing the
database adapter. It's also raising an exception on Gemfiles such as
the following:

```
gem 'pg', platform: :mri
gem 'activerecord-jdbcpostgresql-adapter', platform: :jruby
```

With this change, we only select the gems that are defined for the
current platform.
