### PR TITLE
Add missing 's' to `platforms`

### DIFF
--- a/lib/railblazer/gem.rb
+++ b/lib/railblazer/gem.rb
@@ -20,7 +20,7 @@ module Railblazer
 
     def gem_platforms
       if args.is_a? Hash
-        Array(args[:platform])
+        Array(args[:platforms])
       else
         []
       end

--- a/spec/railblazer/gem_spec.rb
+++ b/spec/railblazer/gem_spec.rb
@@ -3,25 +3,25 @@ require 'spec_helper'
 describe Railblazer::Gem do
   describe "#for_current_platform?" do
     it "returns true if ruby platform is Java and gem platform is jruby" do
-      gem = Railblazer::Gem.new([{platform: :jruby}])
+      gem = Railblazer::Gem.new([{platforms: :jruby}])
       gem.stubs(:current_ruby_platform).returns("java")
       gem.for_current_platform?.must_equal true
     end
 
     it "returns false if ruby platform is Java and gem platform is mri" do
-      gem = Railblazer::Gem.new([{platform: :mri}])
+      gem = Railblazer::Gem.new([{platforms: :mri}])
       gem.stubs(:current_ruby_platform).returns("java")
       gem.for_current_platform?.must_equal false
     end
 
     it "returns true if ruby platform is not Java and gem platform is mri" do
-      gem = Railblazer::Gem.new([{platform: :mri}])
+      gem = Railblazer::Gem.new([{platforms: :mri}])
       gem.stubs(:current_ruby_platform).returns("something_entirely_different")
       gem.for_current_platform?.must_equal true
     end
 
     it "returns false if ruby platform is not Java and gem platform is jruby" do
-      gem = Railblazer::Gem.new([{platform: :jruby}])
+      gem = Railblazer::Gem.new([{platforms: :jruby}])
       gem.stubs(:current_ruby_platform).returns("something_entirely_different")
       gem.for_current_platform?.must_equal false
     end
@@ -33,7 +33,7 @@ describe Railblazer::Gem do
     end
 
     it "works when platform is an array" do
-      gem = Railblazer::Gem.new([{platform: [:jruby]}])
+      gem = Railblazer::Gem.new([{platforms: [:jruby]}])
       gem.stubs(:current_ruby_platform).returns("java")
       gem.for_current_platform?.must_equal true
     end

--- a/spec/railblazer/minimal_gemfile_spec.rb
+++ b/spec/railblazer/minimal_gemfile_spec.rb
@@ -16,7 +16,7 @@ describe Railblazer::MinimalGemfile do
     it "should detect gems inside of group blocks" do
       mysql_gemfile = <<-EOF
         gem 'mysql'
-        gem 'pg', platform: :jruby
+        gem 'pg', platforms: :jruby
         group 'development' do
           gem 'othergem'
         end
@@ -27,8 +27,8 @@ describe Railblazer::MinimalGemfile do
 
     it "should detect for the current platform" do
       pg_gemfile = <<-EOF
-        gem 'mysql', platform: :mri
-        gem 'pg', platform: :jruby
+        gem 'mysql', platforms: :mri
+        gem 'pg', platforms: :jruby
         group 'development' do
           gem 'othergem'
         end


### PR DESCRIPTION
The actual use of this option is `gem 'pg', platforms: :jruby`, not `gem 'pg', platform: :jruby`. This is a problem since gems that were not specific to the current Ruby platform were getting added to the gem list.

This was specially problematic because multiple DB adaptors were getting into the gem list when the same adaptor was being used for different platforms, which caused "More than one adapter gem found in Gemfile!" to be raised. Example:

```
gem 'activerecord-jdbcpostgresql-adapter', platforms: :jruby
gem 'pg', platforms: :mri
```
